### PR TITLE
fix Chinese word typo, from "都讲" -> "都将"

### DIFF
--- a/docs/lifetime/instance-scope.rst
+++ b/docs/lifetime/instance-scope.rst
@@ -56,7 +56,7 @@
     var builder = new ContainerBuilder();
     builder.RegisterType<Worker>().SingleInstance();
 
-当你解析一个单一实例组件时, 无论你从哪里请求它, 你都讲获得相同的实例.
+当你解析一个单一实例组件时, 无论你从哪里请求它, 你都将获得相同的实例.
 
 .. sourcecode:: csharp
 


### PR DESCRIPTION
fix Chinese word typo, from "都讲" -> "都将" 
where 
"它也被称为 '单例.' 使用单一实例作用域, 在根容器和所有嵌套作用域内所有的请求都 **讲** 会返回同一个实例."